### PR TITLE
Add timing for workshops

### DIFF
--- a/data/pricing.yml
+++ b/data/pricing.yml
@@ -8,7 +8,7 @@ prices:
       - type: "Normal bird"
         price: "$180"
         state: "active"
-      - type: "Student tickets"
+      - type: "Student tickets - thanks to <a href='https://www.summeroftech.co.nz'>Summer of Tech</a>"
         price: "$50"
         state: "active"
   - type: "Workshop day"

--- a/data/workshops.yml
+++ b/data/workshops.yml
@@ -1,66 +1,73 @@
-workshop_list:
-  - title: "Next Generation Web Apps with dry-rb"
-    slug: "dry-rb"
-    long: "Full day"
-    level: "Intermediate level"
-    description: "Found yourself tangled up in hard-to-maintain code? Been building app after app in the same way and never finding a way to make significant improvements? Vaunted object-oriented design principles proving too elusive or hard to apply? Thinking maybe it’s time to leave Ruby (gasp!) for something different?
-
-If you’ve answered yes to any of these questions, this workshop is for you!
-
-Come along and learn how to build a new generation of Ruby web app with dry-rb: an app that is robust, cleanly architected, and just as easy to build now as it will be to maintain later."
-    presenters:
-      - name: "Tim Riley"
-        avatar: "tim.jpeg"
-        bio: "Tim is a partner at Australian design and development agency Icelab, a co-founder and core developer of dry-rb, and a core developer of rom-rb. He’s been working exclusively with this stack for 2 years, and is excited about advancing the state of web development in Ruby."
-      - name: "Andrew Croome"
-        avatar: "andrew.jpeg"
-        bio: "Andrew is a Ruby developer with Icelab. He likes books, Melbourne weather and dry-rb. As the author of several novels, he loves clean code and clean prose."
-  - title: "Defensive DevOps"
-    slug: "defensive-devops"
-    long: "Half-day"
-    level: "Intermediate level"
-    description: "The DevOps revolution is in full swing, with a variety of tools and techniques being announced and implemented every day. Our systems no longer look to deploy on physical hardware, instead aiming to be hosted on the cloud and other virtualised systems.
-But, how do we do this securely? All these automation tools are still programming, and programming is always filled with bugs and security holes.
-In this session, we will go through the rise of the DevOps revolution, and what it means both from a technical and cultural standpoint. We’ll talk about how to model where your points of failure will be, and which ones will be the most catastrophic. We’ll talk about security, how it’s a reliability concern, and how best to make it part of your journey to sustainability.
-This workshop will be presented by aurynn shaw, founder of Eiara - Sustainable DevOps"
-    presenters:
-      - name: "aurynn shaw"
-        avatar: "aurynn.jpeg"
-        bio: "aurynn is the founder of Eiara, a DevOps consultancy based out of Wellington, New Zealand, focussing on helping clients develop technical DevOps capability, and the cultural knowledge to use it.
-
-aurynn brings a unique expertise in integrating deployment and security to the modern software development process, by treating both as part of the broader reliability and maintenance workflow.
-
-With over a decade as a professional software developer, aurynn’s expertise ranges from modern cloud deployments to massively parallel supercomputer environments. "
-    sponsors:
-      - name: "Eiara - Sustainable DevOps"
-        avatar: "eiara.png"
-        bio: "Eiara specialises in working with clients to develop DevOps processes and pipelines, bringing security and reliability to the entire software development process. Eiara also focusses on working with clients to manage the technical requirements and cultural impacts of new and existing processes within the organisation, to meed the short, medium and long-term needs of the business."
-        link: "http://www.eiara.nz"
-  - title: "RSpec++"
-    slug: "rspec"
-    long: "Half-day"
-    level: "Intermediate level"
-    description: "You've been using RSpec for a while, you know how to write tests, but you're not sure you're getting the most from it. Let's spend some time working with the more advanced features, changes in newer versions and how to customise your setup."
-    presenters:
-      - name: "Jon Rowe"
-        avatar: "jon.jpeg"
-        bio: "Tinker. Sailor. Developer. Spy? Originally from a tiny cold island nation, Britain, Jon now lives in Sydney where he spends time sailing the high seas, plotting and working as a gun for hire, I mean freelance Ruby developer. When not working on client work you can find Jon hacking on RSpec (as a core team member), helping other open source projects and working on his own little side project(s)."
-  - title: "Machine Learning for Developers"
-    slug: "machine-learning"
-    long: "Half-day"
-    level: "Intermediate level"
-    description: "You don't have to be a data scientist or an algorithm guru to effectively use machine learning. Come to this workshop to try machine learning out for yourself, and learn the main principles and processes for implementing machine learning. By the end of this workshop, you  will be able to identify problems that can be solved with machine learning, understand what makes a good training dataset, and validate your solutions."
-    presenters:
-      - name: "Mai Nguyen"
-        avatar: "mai.jpeg"
-        bio: "Mai is a Senior Developer at Loyalty NZ. Before moving to Wellington, she took a hiatus from tech to study winemaking, and travel the world. In her spare time she explores ways to use technology to make wine information more accessible to the public."
-  - title: "Engineering Empathy"
-    slug: "engineering-empathy"
-    long: "Half-day"
-    level: "Any level"
-    description: "This is a fun and interactive workshop where you will learn skills for giving and receiving effective feedback and having difficult conversations with confidence and empathy. You learn how trust and empathy affect your work and how to enhance your natural empathy to make your teams more productive. You will practice techniques that combat impostor syndrome and leave you feeling bold and courageous."
-    presenters:
-      - name: "Sarrah Jayne"
-        avatar: "sarrah.jpeg"
-        bio: "Sarrah is a teacher at Enspiral Dev Academy; for the last 2 years she has developed and delivered the soft skills programme that runs alongside the technical curriculum. Sarrah has a background in yoga and mindfulness and with that brings a unique perspective to empathy in the tech culture. She has taught about 300 students all of whom have found ample personal and professional growth.
-  Sarrah and Enspiral Dev Academy have recently started to expand the curriculum to take it into tech start ups and established businesses who are ready to take their team to the next level."
+workshop_timeslots:
+  - time: "All day"
+    workshops:
+      - title: "Next Generation Web Apps with dry-rb"
+        slug: "dry-rb"
+        long: "Full day"
+        level: "Intermediate level"
+        description:
+          - "Found yourself tangled up in hard-to-maintain code? Been building app after app in the same way and never finding a way to make significant improvements? Vaunted object-oriented design principles proving too elusive or hard to apply? Thinking maybe it’s time to leave Ruby (gasp!) for something different?"
+          - "If you’ve answered yes to any of these questions, this workshop is for you!"
+          - "Come along and learn how to build a new generation of Ruby web app with dry-rb: an app that is robust, cleanly architected, and just as easy to build now as it will be to maintain later."
+        presenters:
+          - name: "Tim Riley"
+            avatar: "tim.jpeg"
+            bio: "Tim is a partner at Australian design and development agency Icelab, a co-founder and core developer of dry-rb, and a core developer of rom-rb. He’s been working exclusively with this stack for 2 years, and is excited about advancing the state of web development in Ruby."
+          - name: "Andrew Croome"
+            avatar: "andrew.jpeg"
+            bio: "Andrew is a Ruby developer with Icelab. He likes books, Melbourne weather and dry-rb. As the author of several novels, he loves clean code and clean prose."
+  - time: "Morning"
+    workshops:
+      - title: "Defensive DevOps"
+        slug: "defensive-devops"
+        long: "Half-day"
+        level: "Intermediate level"
+        description:
+          - "The DevOps revolution is in full swing, with a variety of tools and techniques being announced and implemented every day. Our systems no longer look to deploy on physical hardware, instead aiming to be hosted on the cloud and other virtualised systems."
+          - "But, how do we do this securely? All these automation tools are still programming, and programming is always filled with bugs and security holes."
+          - "In this session, we will go through the rise of the DevOps revolution, and what it means both from a technical and cultural standpoint. We’ll talk about how to model where your points of failure will be, and which ones will be the most catastrophic. We’ll talk about security, how it’s a reliability concern, and how best to make it part of your journey to sustainability."
+          - "This workshop will be presented by aurynn shaw, founder of Eiara - Sustainable DevOps"
+        presenters:
+          - name: "aurynn shaw"
+            avatar: "aurynn.jpeg"
+            bio: "aurynn is the founder of Eiara, a DevOps consultancy based out of Wellington, New Zealand, focussing on helping clients develop technical DevOps capability, and the cultural knowledge to use it.
+    aurynn brings a unique expertise in integrating deployment and security to the modern software development process, by treating both as part of the broader reliability and maintenance workflow.
+    With over a decade as a professional software developer, aurynn’s expertise ranges from modern cloud deployments to massively parallel supercomputer environments. "
+        sponsors:
+          - name: "Eiara - Sustainable DevOps"
+            avatar: "eiara.png"
+            bio: "Eiara specialises in working with clients to develop DevOps processes and pipelines, bringing security and reliability to the entire software development process. Eiara also focusses on working with clients to manage the technical requirements and cultural impacts of new and existing processes within the organisation, to meet the short, medium and long-term needs of the business."
+            link: "http://www.eiara.nz"
+      - title: "RSpec++"
+        slug: "rspec"
+        long: "Half-day"
+        level: "Intermediate level"
+        description:
+          - "You've been using RSpec for a while, you know how to write tests, but you're not sure you're getting the most from it. Let's spend some time working with the more advanced features, changes in newer versions and how to customise your setup."
+        presenters:
+          - name: "Jon Rowe"
+            avatar: "jon.jpeg"
+            bio: "Tinker. Sailor. Developer. Spy? Originally from a tiny cold island nation, Britain, Jon now lives in Sydney where he spends time sailing the high seas, plotting and working as a gun for hire, I mean freelance Ruby developer. When not working on client work you can find Jon hacking on RSpec (as a core team member), helping other open source projects and working on his own little side project(s)."
+  - time: "Afternoon"
+    workshops:
+      - title: "Machine Learning for Developers"
+        slug: "machine-learning"
+        long: "Half-day"
+        level: "Intermediate level"
+        description:
+          - "You don't have to be a data scientist or an algorithm guru to effectively use machine learning. Come to this workshop to try machine learning out for yourself, and learn the main principles and processes for implementing machine learning. By the end of this workshop, you  will be able to identify problems that can be solved with machine learning, understand what makes a good training dataset, and validate your solutions."
+        presenters:
+          - name: "Mai Nguyen"
+            avatar: "mai.jpeg"
+            bio: "Mai is a Senior Developer at Loyalty NZ. Before moving to Wellington, she took a hiatus from tech to study winemaking, and travel the world. In her spare time she explores ways to use technology to make wine information more accessible to the public."
+      - title: "Engineering Empathy"
+        slug: "engineering-empathy"
+        long: "Half-day"
+        level: "Any level"
+        description:
+          - "This is a fun and interactive workshop where you will learn skills for giving and receiving effective feedback and having difficult conversations with confidence and empathy. You learn how trust and empathy affect your work and how to enhance your natural empathy to make your teams more productive. You will practice techniques that combat impostor syndrome and leave you feeling bold and courageous."
+        presenters:
+          - name: "Sarrah Jayne"
+            avatar: "sarrah.jpeg"
+            bio: "Sarrah is a teacher at Enspiral Dev Academy; for the last 2 years she has developed and delivered the soft skills programme that runs alongside the technical curriculum. Sarrah has a background in yoga and mindfulness and with that brings a unique perspective to empathy in the tech culture. She has taught about 300 students all of whom have found ample personal and professional growth.
+      Sarrah and Enspiral Dev Academy have recently started to expand the curriculum to take it into tech start ups and established businesses who are ready to take their team to the next level."

--- a/source/assets/public/index.css
+++ b/source/assets/public/index.css
@@ -339,6 +339,9 @@ strong {
   font-weight: bold;
   letter-spacing: 0.05rem;
 }
+.t-small {
+  font-size: 0.75em !important;
+}
 .swash {
   font-family: var(--font-logotype)
 }
@@ -708,3 +711,8 @@ p.c-price-list__description {
   .c-price-list__action--inactive:hover {
     background-color: #FFF;
   }
+
+
+.c-short-list__item {
+  margin-bottom: 0.5rem;
+}

--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -11,8 +11,20 @@ section
       ' Kiwi Ruby is a new Ruby conference being held in Wellington, New Zealand.
     p
       ' With a mixture of local and international speakers, there will be one day of workshops and one single-track day of talks. We'll cover topics that interest, excite, and delight Rubyists and the Ruby-curious of all levels.
-    p
-      ' It's being held on Thursday 2 November (workshops) and Friday 3 November (conference) at Te Papa on the Wellington waterfront.
+  .body-inner-wrapper__section#conference
+    h2 🎙 Conference
+    p The conference will be held in the beautiful Soundings Theatre at Te Papa on the 3rd of November. We'll provide lunch and plenty of opportunities for you to get to know other attendees.
+    p We have a stellar single-track lineup of talks. You'll learn something whether you've been writing Ruby for ten years or ten minutes.
+    .c-short-list
+      - data.speakers.speaker_list.each do |speaker|
+        .c-short-list__item
+          a href=("/talks##{speaker.slug}") = speaker.talk.title
+          '&nbsp;—
+          span=speaker.name
+  .body-inner-wrapper__section#workshops
+    h2 💻 Workshops
+    p We're holding one day of deep-dive workshops on the 2nd of November. One ticket gets you a day of workshops - either one full-day workshop, or one in the morning and one in the afternoon.
+    = partial "partials/workshop_times"
   .body-inner-wrapper__section#prices
     h2 🎟 Sign me up
     p Thanks to our <a href="/#sponsors">generous sponsors</a> for allowing us to set ticket prices at a level that we hope is affordable for you and your whole team.

--- a/source/partials/_workshop_times.html.slim
+++ b/source/partials/_workshop_times.html.slim
@@ -1,0 +1,16 @@
+.grid.c-price-list
+  - data.workshops.workshop_timeslots.each do |timeslot|
+    .col-1-3.c-price-list__item
+      span.c-price-list__type=timeslot.time
+      - timeslot.workshops.each do |workshop|
+        .c-price-list__rate
+          p
+            a href=("/workshops/##{workshop.slug}")
+              =workshop.title
+          p
+            strong=workshop.presenters.map(&:name).join(", ")
+          - if workshop.sponsors
+            p.t-small
+              ' Thanks to
+              - workshop.sponsors.each do |sponsor|
+                a(href=sponsor.link)=sponsor.name

--- a/source/partials/_workshops.html.slim
+++ b/source/partials/_workshops.html.slim
@@ -1,29 +1,29 @@
-.grid.c-workshop-list
-  - data.workshops.workshop_list.each do |workshop|
-    .c-workshop.col-1-2 id=workshop.slug
-      .c-workshop__details
-        h3.c-workshop__title = workshop.title
-        .c-workshop__detail
-          p
-            span= "#{workshop.long}"
-            = "#{workshop.level}"
-        .c-workshop__description
-          p = workshop.description
-
-      .c-workshop__presenter
-        - workshop.presenters.each do |presenter|
-          .c-workshop__presenter-details
-            img.c-speaker__avatar.c-speaker__avatar--small src=("/images/workshop-avatars/#{presenter.avatar}") alt=(presenter.name)
-            span.c-presenter__title = "#{presenter.name}"
-            .c-workshop__presenter-bio
-              p = presenter.bio
-      - if workshop.sponsors
-        - workshop.sponsors.each do |sponsor|
-          .c-workshop__presenter-details
-            h3.t-small-caps Sponsored by:
-            a href=(sponsor.link) target="_blank" rel="noopener noreferrer"
-              img.c-workshop__sponsor.c-speaker__avatar src=("/images/workshop-avatars/#{sponsor.avatar}") alt=(sponsor.name)
-            a.c-presenter__title href=(sponsor.link) target="_blank" rel="noopener noreferrer"
-              ="#{sponsor.name}"
-            .c-workshop__presenter-bio
-              p = sponsor.bio
+- data.workshops.workshop_timeslots.each do |timeslot|
+  h2=timeslot.time
+  .grid.c-workshop-list
+    - timeslot.workshops.each do |workshop|
+      .c-workshop.col-1-2 id=workshop.slug
+        .c-workshop__details
+          h3.c-workshop__title = workshop.title
+          .c-workshop__detail
+            p= "#{workshop.level}"
+          .c-workshop__description
+            - workshop.description.each do |paragraph|
+              p = paragraph
+        .c-workshop__presenter
+          - workshop.presenters.each do |presenter|
+            .c-workshop__presenter-details
+              img.c-speaker__avatar.c-speaker__avatar--small src=("/images/workshop-avatars/#{presenter.avatar}") alt=(presenter.name)
+              span.c-presenter__title = "#{presenter.name}"
+              .c-workshop__presenter-bio
+                p = presenter.bio
+        - if workshop.sponsors
+          - workshop.sponsors.each do |sponsor|
+            .c-workshop__presenter-details
+              h3.t-small-caps Sponsored by:
+              a href=(sponsor.link) target="_blank" rel="noopener noreferrer"
+                img.c-workshop__sponsor.c-speaker__avatar src=("/images/workshop-avatars/#{sponsor.avatar}") alt=(sponsor.name)
+              a.c-presenter__title href=(sponsor.link) target="_blank" rel="noopener noreferrer"
+                ="#{sponsor.name}"
+              .c-workshop__presenter-bio
+                p = sponsor.bio


### PR DESCRIPTION
Add in timing for workshops, and re-organise the front page a little to reflect the details now available.

@tobydallder FYI - will probably deploy this before you look at it because I'd like to announce the timing asap - but you're welcome to rejig

<details>
<summary>Front page - desktop</summary>

![screencapture-localhost-4567-1501987534592](https://user-images.githubusercontent.com/1615322/29000128-8a961e4c-7ab6-11e7-879f-4c2ee2f501d3.png)

</details>

<details>
<summary>Front page - mobile</summary>

![screencapture-localhost-4567-1501987545780](https://user-images.githubusercontent.com/1615322/29000129-9a544f48-7ab6-11e7-879a-59d793be3581.png)

</details>

<details>
<summary>Workshop page - desktop</summary>

![screencapture-localhost-4567-workshops-1501987569694](https://user-images.githubusercontent.com/1615322/29000133-b34667e8-7ab6-11e7-8f74-ed704f2f0994.png)

</details>

<details>
<summary>Workshop page - mobile</summary>

![screencapture-localhost-4567-workshops-1501987562418](https://user-images.githubusercontent.com/1615322/29000137-c604f7c8-7ab6-11e7-9661-2d4b22390477.png)

</details>