### PR TITLE
Replace Google Maps iframe with Google Static Map image(s)

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -15,7 +15,6 @@ set :markdown,        fenced_code_blocks: true,
                       no_intra_emphasis: true,
                       lax_spacing: true,
                       with_toc_data: true
-
 # Helpers ----------------------------------------------------------------------
 
 require "lib/typography_helpers"
@@ -84,12 +83,16 @@ activate :directory_indexes
 
 # Reload the browser automatically whenever files change
 configure :development do
+  set :env, "development"
+  set :google_maps_key, nil
   activate :livereload
 end
 
 # Build-specific configuration -------------------------------------------------
 
 configure :build do
+  set :env, "production"
+  set :google_maps_key, "AIzaSyBdI51q8kJ9s19RmWunLFFUZKFTxDXTSBA"
 end
 
 # Deployment configuration -----------------------------------------------------

--- a/data/venue.yml
+++ b/data/venue.yml
@@ -1,0 +1,21 @@
+name: Musuem of New Zealand, Te Papa, Tongarewa
+nickname: Te Papa
+address: 55 Cable Street, Te Aro, Wellington 6011, New Zealand
+url: https://www.tepapa.govt.nz/
+location:
+  lat: -41.2905022
+  long: 174.7817372
+maps:
+  url: https://goo.gl/maps/ZSehkwLEvk52
+  img_src_base: https://maps.googleapis.com/maps/api/staticmap?center=Te+Papa%2C+Wellington%2C+New+Zealand&maptype=roadmap
+  sizes:
+  - name: large
+    breakpoint: "min-width: 640px"
+    zoom: 16
+    dimensions: "640x400"
+    scale: 2
+  - name: small 
+    breakpoint: "max-width: 639px"
+    zoom: 15
+    dimensions: "320x200"
+    scale: 2

--- a/data/venue.yml
+++ b/data/venue.yml
@@ -1,4 +1,4 @@
-name: Musuem of New Zealand, Te Papa, Tongarewa
+name: Museum of New Zealand, Te Papa Tongarewa
 nickname: Te Papa
 address: 55 Cable Street, Te Aro, Wellington 6011, New Zealand
 url: https://www.tepapa.govt.nz/

--- a/source/assets/public/index.css
+++ b/source/assets/public/index.css
@@ -505,16 +505,12 @@ strong {
 .c-responsive-map {
     max-width: 85rem;
     position: relative;
-    padding-bottom: 55%;
-    height: 0;
-    overflow: hidden;
 }
-.c-responsive-map iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100% !important;
-    height: 100% !important;
+.c-responsive-map a {
+  border: none;
+}
+.c-responsive-map img {
+  max-width: 100%;
 }
 
 .h-lots-of-padding-top {

--- a/source/partials/_te_papa_map.html.slim
+++ b/source/partials/_te_papa_map.html.slim
@@ -1,8 +1,12 @@
 .c-responsive-map
-  <iframe width="450"
-  '        height="250"
-  '        frameborder="0"
-  '        style="border:0"
-  '        src="https://www.google.com/maps/embed/v1/place?key=AIzaSyDaFJR5kaMRyXO_-1alNS9BNbMHrLHVilk&q='Te Papa, Wellington, New Zealand'"
-  '        allowfullscreen>
-  </iframe>
+  a href=data.venue.maps.url target="_blank" rel="noopener nofollow"
+    picture
+      - data.venue.maps.sizes.each do |item|
+        source [ 
+          media="(#{item.breakpoint})"
+          srcset="#{data.venue.maps.img_src_base}&scale=#{item.scale}&zoom=#{item.zoom}&size=#{item.dimensions}&markers=#{data.venue.location.lat}%2C#{data.venue.location.long}"
+        ]
+      img [
+        alt="Map to #{data.venue.nickname}"
+        src="#{data.venue.maps.img_src_base}&scale=#{data.venue.maps.sizes.first.scale}&zoom=#{data.venue.maps.sizes.first.zoom}&size=#{data.venue.maps.sizes.first.dimensions}&markers=#{data.venue.location.lat}%2C#{data.venue.location.long}"
+      ]

--- a/source/partials/_te_papa_map.html.slim
+++ b/source/partials/_te_papa_map.html.slim
@@ -1,12 +1,23 @@
+- url = data.venue.maps.img_src_base \
+  + "&key=#{config[:google_maps_key]}" \
+  + "&markers=#{data.venue.location.lat}%2C#{data.venue.location.long}"
+- fallBackUrl = url \
+  + "&scale=#{data.venue.maps.sizes.first.scale}" \
+  + "&zoom=#{data.venue.maps.sizes.first.zoom}" \
+  + "&size=#{data.venue.maps.sizes.first.dimensions}"
 .c-responsive-map
   a href=data.venue.maps.url target="_blank" rel="noopener nofollow"
     picture
       - data.venue.maps.sizes.each do |item|
+        - itemUrl = url \
+          + "&scale=#{item.scale}" \
+          + "&zoom=#{item.zoom}" \
+          + "&size=#{item.dimensions}"
         source [ 
           media="(#{item.breakpoint})"
-          srcset="#{data.venue.maps.img_src_base}&scale=#{item.scale}&zoom=#{item.zoom}&size=#{item.dimensions}&markers=#{data.venue.location.lat}%2C#{data.venue.location.long}"
+          srcset=itemUrl
         ]
       img [
         alt="Map to #{data.venue.nickname}"
-        src="#{data.venue.maps.img_src_base}&scale=#{data.venue.maps.sizes.first.scale}&zoom=#{data.venue.maps.sizes.first.zoom}&size=#{data.venue.maps.sizes.first.dimensions}&markers=#{data.venue.location.lat}%2C#{data.venue.location.long}"
+        src=fallBackUrl
       ]


### PR DESCRIPTION
This PR fixes #36 and adds a dynamically generated Google Static Map from a new data file: `venue.yml`

**Note:** A Google Maps API key is required to unlock 25,000 free requests a day.

Before:

![map_before](https://user-images.githubusercontent.com/107569/30200646-f2531a9c-94cb-11e7-953c-0125b346619a.png)

After: 

![map_after](https://user-images.githubusercontent.com/107569/30200647-f2561e7c-94cb-11e7-8c4f-c277eae3f937.png)

