### PR TITLE
Better handling of Google Analytics

### DIFF
--- a/source/assets/public/ga.js
+++ b/source/assets/public/ga.js
@@ -1,4 +1,11 @@
-javascript:
+function DNT () {
+  if ('msDoNotTrack' in navigator) return navigator.msDoNotTrack;
+  if ('doNotTrack' in window)      return window.doNotTrack;
+  if ('doNotTrack' in navigator)   return navigator.doNotTrack;
+  return 0;
+};
+
+if (DNT() == 0) {
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -6,3 +13,4 @@ javascript:
 
   ga('create', 'UA-98197426-1', 'auto');
   ga('send', 'pageview');
+}

--- a/source/assets/public/target.js
+++ b/source/assets/public/target.js
@@ -8,6 +8,7 @@ require('./index.css')
 // Require the base JS, basically our entry point for JS
 // If your target doesn't require JavaScript you can comment this out
 require('./index.js')
+require('./ga.js');
 
 // Require all images and CSS by default
 // This will inspect all subdirectories from the context (first param) and

--- a/source/layouts/base.slim
+++ b/source/layouts/base.slim
@@ -3,7 +3,6 @@ html lang="en-NZ"
   head
     meta charset="UTF-8"
     = partial "partials/head_breakpoints"
-    = partial "partials/head_ga"
     title
       => current_page.data.title
       ' —


### PR DESCRIPTION
This PR:

- Removes the inline script from the base template
- Adds the GA script in the main JS manifest
- Will only invoke GA if DoNotTrack is not set to 1.

See: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack