### PR TITLE
Remove dependency on jQuery and refactor mobile menu

### DIFF
--- a/source/assets/public/index.css
+++ b/source/assets/public/index.css
@@ -157,7 +157,10 @@ body {
     padding: 2rem;
     font-size: 2rem;
     border-bottom: 1px solid #EEE;
-    color: var(--font-body);
+    color: var(--text-color);
+  }
+  .nav--mobile__show:visited {
+    color: var(--text-color);
   }
   .nav--mobile__show::before {
     content: '';

--- a/source/assets/public/index.css
+++ b/source/assets/public/index.css
@@ -127,11 +127,21 @@ body {
     color: var(--primary-color-darker);
   }
 
-  .nav.nav--mobile,
+  .nav--mobile {
+    transform-origin: 0 0;
+    transform: scale(0);
+    transition: transform .2s;
+    z-index: 1;
+  }
+  .nav--mobile.active {
+    transform: scale(1);
+  }
+
+  .breakpoint-tablet .nav--mobile,
   .breakpoint-tablet .nav--mobile__show,
+  .breakpoint-desktop-up .nav--mobile,
   .breakpoint-desktop-up .nav--mobile__show {
     display: none;
-    z-index: 5;
   }
 
   .breakpoint-phone .nav__room {

--- a/source/assets/public/index.js
+++ b/source/assets/public/index.js
@@ -9,18 +9,18 @@ var mobileNavTrigger = document.querySelector('.nav--mobile__show');
 function bodyClickHandler(event) {
   var trigger = event.target;
   if (trigger == mobileNavTrigger) {return;}
-  closeMneu();
+  closeMenu();
 }
 function openMenu () {
   mobileNavContainer.classList.add('active');
   body.addEventListener('click', bodyClickHandler);
 }
-function closeMneu () {
+function closeMenu () {
   mobileNavContainer.classList.remove('active');
   body.removeEventListener('click', bodyClickHandler);
 }
 
 mobileNavTrigger.addEventListener('click', function(e){
   e.preventDefault();
-  mobileNavContainer.classList.contains('active') ? closeMneu() : openMenu();
+  mobileNavContainer.classList.contains('active') ? closeMenu() : openMenu();
 });

--- a/source/assets/public/index.js
+++ b/source/assets/public/index.js
@@ -1,33 +1,26 @@
 /**
  * JavaScript goes here
  */
-$(document).ready(function () {
-  mobileNav();
+
+var body = document.body;
+var mobileNavContainer = document.querySelector('.nav--mobile');
+var mobileNavTrigger = document.querySelector('.nav--mobile__show');
+
+function bodyClickHandler(event) {
+  var trigger = event.target;
+  if (trigger == mobileNavTrigger) {return;}
+  closeMneu();
+}
+function openMenu () {
+  mobileNavContainer.classList.add('active');
+  body.addEventListener('click', bodyClickHandler);
+}
+function closeMneu () {
+  mobileNavContainer.classList.remove('active');
+  body.removeEventListener('click', bodyClickHandler);
+}
+
+mobileNavTrigger.addEventListener('click', function(e){
+  e.preventDefault();
+  mobileNavContainer.classList.contains('active') ? closeMneu() : openMenu();
 });
-
-function hide ($element) {
-  $($element).hide(200);
-  $($element).removeClass('active');
-}
-
-function mobileNav () {
-  var $mobileNav = $('.nav--mobile');
-
-  $('.nav--mobile__show').click(function () {
-    if ( $mobileNav.hasClass('active') ) {
-      hide($mobileNav);
-      return;
-    }
-
-    $mobileNav.addClass('active');
-    $mobileNav.show(200);
-  });
-
-  $('body').click(function (event) {
-    if (!$mobileNav.hasClass('active')) { return; }
-    if ($(event.target).is('.nav--mobile__show') || $(event.target).parent().is('.nav--mobile__show')) { return; }
-
-    $($mobileNav).removeClass('active');
-    hide($mobileNav);
-  });
-}

--- a/source/layouts/base.slim
+++ b/source/layouts/base.slim
@@ -11,9 +11,8 @@ html lang="en-NZ"
     = partial "partials/head_opengraph"
     = partial "partials/head_pwa"
   body.nav__room
-    div.nav--mobile__show
-      i.fa.fa-bars aria-hidden="true"
-      span Menu
+    a.nav--mobile__show href="#menu_mobile"
+      | Menu
     = partial "partials/nav", locals: { nav_type: "header" }
     = partial "partials/nav", locals: { nav_type: "mobile" }
     .mw-spacer

--- a/source/layouts/base.slim
+++ b/source/layouts/base.slim
@@ -8,8 +8,6 @@ html lang="en-NZ"
       ' —
       = data.site.name
     link rel="stylesheet" href=asset_path(:css, "assets/public")
-    script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js">
-    script async=true src=asset_path(:js, "assets/public")
     = partial "partials/head_opengraph"
     = partial "partials/head_pwa"
   body.nav__room
@@ -22,3 +20,4 @@ html lang="en-NZ"
       .container
         = yield
         = partial "partials/footer"
+    script async=true src=asset_path(:js, "assets/public")

--- a/source/partials/_nav.html.slim
+++ b/source/partials/_nav.html.slim
@@ -1,4 +1,4 @@
-.nav class=("nav--#{nav_type}")
+.nav class=("nav--#{nav_type}") id="menu_#{nav_type}"
   ul.nav__content
     li.nav__item
       a href="/" Kiwi&nbsp;Ruby


### PR DESCRIPTION
This PR: 

- Remove jQuery.
- Refactor mobile nav script.
- Move public script to end of doc.
- Use native accessibility for the menu toggle by switching to an anchor for the mobile menu trigger.
- Emulate the current animation by using scale transitions from the top left.

Before | After
------- | -------
<img width="409" alt="Before" src="https://user-images.githubusercontent.com/107569/30262737-2fb4f5e8-9726-11e7-9384-8b2a9db3a8e4.png"> | <img width="408" alt="After" src="https://user-images.githubusercontent.com/107569/30262736-2fb3b822-9726-11e7-8d46-5aa06d7e33b4.png">

![animation](https://user-images.githubusercontent.com/107569/30263059-97981248-9727-11e7-8fd8-b8c3cebcbd71.gif)
