### PR TITLE
Fix: DoNotTrack check

### DIFF
--- a/source/assets/public/ga.js
+++ b/source/assets/public/ga.js
@@ -5,7 +5,7 @@ function DNT () {
   return 0;
 };
 
-if (DNT() == 0) {
+if (DNT() != 1) {
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)


### PR DESCRIPTION
Some browsers respond with DNT: `null` when off and not the expected `0`.