### PR TITLE
Fix to anchor links

### DIFF
--- a/data/workshops.yml
+++ b/data/workshops.yml
@@ -1,5 +1,5 @@
 workshop_timeslots:
-  - time: "All day"
+  - time: "All day • 9:30am—5:30pm"
     workshops:
       - title: "Next Generation Web Apps with dry-rb"
         slug: "dry-rb"
@@ -16,7 +16,7 @@ workshop_timeslots:
           - name: "Andrew Croome"
             avatar: "andrew.jpeg"
             bio: "Andrew is a Ruby developer with Icelab. He likes books, Melbourne weather and dry-rb. As the author of several novels, he loves clean code and clean prose."
-  - time: "Morning"
+  - time: "Morning • 9:30am—1:00pm"
     workshops:
       - title: "Defensive DevOps"
         slug: "defensive-devops"
@@ -48,7 +48,7 @@ workshop_timeslots:
           - name: "Jon Rowe"
             avatar: "jon.jpeg"
             bio: "Tinker. Sailor. Developer. Spy? Originally from a tiny cold island nation, Britain, Jon now lives in Sydney where he spends time sailing the high seas, plotting and working as a gun for hire, I mean freelance Ruby developer. When not working on client work you can find Jon hacking on RSpec (as a core team member), helping other open source projects and working on his own little side project(s)."
-  - time: "Afternoon"
+  - time: "Afternoon • 2pm—5:30pm"
     workshops:
       - title: "Machine Learning for Developers (SOLD OUT)"
         slug: "machine-learning"

--- a/source/assets/public/index.css
+++ b/source/assets/public/index.css
@@ -202,7 +202,13 @@ body {
     color: #FFF;
   }
 
-
+  a.nav-offset__anchor {
+    position: absolute;
+    top: -12rem;
+  }
+  .nav-offset__container {
+    position: relative;
+  }
 /*header/nav*/
 .header {
   width: 100%;

--- a/source/events.html.slim
+++ b/source/events.html.slim
@@ -8,7 +8,8 @@ section.h-lots-of-padding-top
     p We hope you make lots of Ruby friends at Kiwi Ruby. We're throwing some social events around the conference to facilitate this.
     p The Ruby NZ <a href="http://ruby.nz/code-of-conduct/" rel="noopener">code of conduct</a> applies to all of these events. We'll do our best to provide a safe and fun environment and you do your best to be friendly ✨
     - data.events.events.each do |event|
-      .c-event(id=event.slug)
+      .c-event.nav-offset__container
+        a.nav-offset__anchor id=event.slug
         h2=event.name
         .grid
           .col-1-4

--- a/source/partials/_speakers.html.slim
+++ b/source/partials/_speakers.html.slim
@@ -1,6 +1,7 @@
 .grid.c-speaker-list
   - data.speakers.speaker_list.each do |speaker|
-    .c-speaker.col-1-2 id=speaker.slug
+    .c-speaker.col-1-2.nav-offset__container
+      a.nav-offset__anchor id=speaker.slug
       img.c-speaker__avatar src=("/images/speaker-avatars/#{speaker.avatar}") alt=(speaker.name)
       h2.c-speaker__talk-title = speaker.name
       p.c-speaker__name
@@ -8,4 +9,3 @@
           = speaker.talk.title
       .c-speaker__bio
         p = speaker.bio
-

--- a/source/partials/_talks.html.slim
+++ b/source/partials/_talks.html.slim
@@ -1,7 +1,8 @@
 .grid.c-talk-list
 - data.schedule.schedule_items.each do |schedule_item|
-  .c-talk id = schedule_item.slug
+  .c-talk.nav-offset__container
     .c-talk__timeslot.col-1-4 = schedule_item.timeslot
+    a.nav-offset__anchor id=schedule_item.slug
     .c-talk__detail.col-3-4
 
       - speaker = data.speakers.speaker_list.find { |speaker| speaker.slug == schedule_item.slug }
@@ -10,9 +11,9 @@
         p.c-talk__abstract = speaker.talk.abstract
         .c-talk__speaker
           img.c-talk__speaker-avatar src=("/images/speaker-avatars/#{speaker.avatar}") alt=(speaker.name)
-          h3.c-talk__speaker-details 
+          h3.c-talk__speaker-details
             a href="/speakers/##{speaker.slug}"
-              = speaker.name 
+              = speaker.name
       - else
         h2.c-talk__title = schedule_item.title
         p.c-talk__abstract = schedule_item.description

--- a/source/partials/_workshops.html.slim
+++ b/source/partials/_workshops.html.slim
@@ -1,8 +1,9 @@
 - data.workshops.workshop_timeslots.each do |timeslot|
-  h2=timeslot.time
+  h2.t-small-caps=timeslot.time
   .grid.c-workshop-list
     - timeslot.workshops.each do |workshop|
-      .c-workshop.col-1-2 id=workshop.slug
+      .c-workshop.col-1-2.nav-offset__container
+        a.nav-offset__anchor id=workshop.slug
         .c-workshop__details
           h2.c-workshop__title = workshop.title
           h3.c-workshop__detail


### PR DESCRIPTION
Anchor links will now go to the appropriate place on the page - also include the workshop times on the workshop page (a few people have asked) and make the times stand out a little.