### PR TITLE
Only run the service-worker in development if config enables it

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -64,7 +64,7 @@ configure :build do
   }
 end
 
-dev_server_task = :enable_sw ? "npm run watch:sw" : "npm run watch"
+dev_server_task = :enable_sw == true ? "npm run watch:sw" : "npm run watch"
 
 activate :external_pipeline,
           name: :webpack,


### PR DESCRIPTION
Looks like I missed a trick for defaulting development environments to having disabled service workers.
This PR ensures `:enable_sw` is true before enabling the service-worker.

In case you have a service worker running locally, you can deactivate it in Chrome by:

1. Opening a tab to http://localhost:4567
2. Opening DevTools
3. Clicking through to: `Application > Service worker`
4. and then clicking `unregister`.