### PR TITLE
Add the `as` attribute to the CSS preload

### DIFF
--- a/source/layouts/base.slim
+++ b/source/layouts/base.slim
@@ -9,7 +9,7 @@ html lang="en-NZ"
       = data.site.name
     - if current_page.data.home
       = inline_css "assets/public.css"
-      link rel="preload" href=asset_path(:css, "assets/public")
+      link rel="preload" as="style" href=asset_path(:css, "assets/public")
     - else
       link rel="stylesheet" href=asset_path(:css, "assets/public")
     = partial "partials/head_dns_prefetch"


### PR DESCRIPTION
This fixes a warning in Chrome by supplying the `as="style"` attribute to the CSS preload.