### PR TITLE
Add build cleaner

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -22,6 +22,7 @@ activate :directory_indexes
 
 require "lib/typography_helpers"
 helpers TypographyHelpers
+require_relative './lib/build_cleaner'
 
 # Page options -----------------------------------------------------------------
 
@@ -51,6 +52,7 @@ end
 # Build-specific configuration -------------------------------------------------
 
 configure :build do
+  activate :build_cleaner
   set :env, "production"
   set :google_maps_key, "AIzaSyBdI51q8kJ9s19RmWunLFFUZKFTxDXTSBA"
   activate :asset_hash, ignore: %w{

--- a/lib/build_cleaner.rb
+++ b/lib/build_cleaner.rb
@@ -1,0 +1,12 @@
+#lib/build_cleaner.rb
+
+class BuildCleaner < Middleman::Extension
+
+  def initialize(app, options_hash={}, &block)
+    super
+    FileUtils.rm_rf app.config[:build_dir]
+  end
+
+end
+
+::Middleman::Extensions.register(:build_cleaner, BuildCleaner)


### PR DESCRIPTION
I suspect the reasons we're seeing font-awesome in the Service Worker cache is because the file still exists in the `build` folder when `middleman build` is run.

This PR adds a helper extension that deletes the `build` folder each time `middlmean build` is run, cleaning up the Middleman Sitemap of astray assets.