### PR TITLE
Refactor the main nav

### DIFF
--- a/source/assets/public/css/nav.css
+++ b/source/assets/public/css/nav.css
@@ -1,0 +1,132 @@
+/* Navigation */
+.nav__room {
+  padding-top: 6rem;
+}
+
+nav {
+  line-height: 3rem;
+  padding: 1.5rem 1rem 1.5rem 0;
+  text-align: center;
+}
+
+nav ul {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  text-align: center;
+  display: flex;
+  flex-wrap: wrap;
+  align-content: space-between;
+  justify-content: space-between;
+}
+
+nav li {
+  display: inline;
+  font-size: 1.6rem;
+  padding-left: 1.5rem;
+  margin-left: 1rem;
+  text-decoration: none;
+}
+
+.nav__item--highlighted {
+  font-weight: bold;
+}
+
+.nav--mobile__show {
+  position: fixed;
+  background-color: #FFFFFF;
+  width: 100%;
+  top: 0;
+  z-index: 6;
+  padding: 2rem;
+  font-size: 2rem;
+  border-bottom: 1px solid #EEE;
+  color: var(--text-color);
+}
+
+.nav--mobile__show:visited {
+  color: var(--text-color);
+}
+
+.nav--mobile__show::before {
+  content: '';
+  background: url("/assets/public/images/bg_menu.svg") 50% 0 no-repeat;
+  display: inline-block;
+  width: 2rem;
+  height: 2rem;
+  vertical-align: middle;
+  margin-right: 1rem;
+}
+
+.nav-offset__container {
+  position: relative;
+}
+
+.nav-offset__anchor {
+  position: absolute;
+  top: -12rem;
+}
+
+@media (max-width:749px) {
+  .nav__room {
+    padding-top: 4em;
+  }
+
+  nav {
+    transform-origin: 0 0;
+    transform: scale(0);
+    transition: transform .2s;
+    z-index: 1;
+    position: fixed;
+    padding: 0;
+    margin: 0;
+    top: 0;
+    width: 100%;
+  }
+
+  nav.js-active {
+    transform: scale(1);
+  }
+  
+  nav ul {
+    background: var(--primary-contrast);
+    width: 100%;
+    padding-top: 6rem;
+    padding-bottom: 3rem;
+    z-index: 5;
+    text-align: left;
+  }
+
+  nav li {
+    font-size: 2rem;
+    padding: 1rem 0;
+    display: block;
+    margin-left: 4rem;
+    margin-right: 2rem;
+  }
+
+  nav a {
+    padding: 0.5rem;
+    padding-left: 0;
+    color: #FFF;
+  }
+
+}
+
+@media (min-width:750px) {
+  .nav--mobile__show {
+    display: none;
+  }
+
+  nav {
+    position: fixed;
+    background-color: white;
+    width: 100%;
+    top: 0;
+    z-index: 5;
+  }
+
+  nav li a:hover {
+    color: var(--primary-color-darker);
+  }
+}
+

--- a/source/assets/public/css/nav.css
+++ b/source/assets/public/css/nav.css
@@ -3,13 +3,13 @@
   padding-top: 6rem;
 }
 
-nav {
+#menu {
   line-height: 3rem;
   padding: 1.5rem 1rem 1.5rem 0;
   text-align: center;
 }
 
-nav ul {
+#menu ul {
   max-width: var(--max-width);
   margin: 0 auto;
   text-align: center;
@@ -19,7 +19,7 @@ nav ul {
   justify-content: space-between;
 }
 
-nav li {
+#menu li {
   display: inline;
   font-size: 1.6rem;
   padding-left: 1.5rem;
@@ -27,7 +27,7 @@ nav li {
   text-decoration: none;
 }
 
-.nav__item--highlighted {
+#menu .nav__item--highlighted {
   font-weight: bold;
 }
 
@@ -71,7 +71,7 @@ nav li {
     padding-top: 4em;
   }
 
-  nav {
+  #menu {
     transform-origin: 0 0;
     transform: scale(0);
     transition: transform .2s;
@@ -83,11 +83,11 @@ nav li {
     width: 100%;
   }
 
-  nav.js-active {
+  #menu.js-active {
     transform: scale(1);
   }
   
-  nav ul {
+  #menu ul {
     background: var(--primary-contrast);
     width: 100%;
     padding-top: 6rem;
@@ -96,7 +96,7 @@ nav li {
     text-align: left;
   }
 
-  nav li {
+  #menu li {
     font-size: 2rem;
     padding: 1rem 0;
     display: block;
@@ -104,7 +104,7 @@ nav li {
     margin-right: 2rem;
   }
 
-  nav a {
+  #menu a {
     padding: 0.5rem;
     padding-left: 0;
     color: #FFF;
@@ -117,7 +117,7 @@ nav li {
     display: none;
   }
 
-  nav {
+  #menu {
     position: fixed;
     background-color: white;
     width: 100%;
@@ -125,7 +125,7 @@ nav li {
     z-index: 5;
   }
 
-  nav li a:hover {
+  #menu li a:hover {
     color: var(--primary-color-darker);
   }
 }

--- a/source/assets/public/index.css
+++ b/source/assets/public/index.css
@@ -26,6 +26,7 @@
 /* Importing css files */
 @import "./grid";
 @import "./footer";
+@import "./css/nav";
 
 /**
  * Styling
@@ -72,134 +73,6 @@ body {
   margin: 0 auto;
 }
 
-/* Navigation */
-
-.nav {
-  line-height: 3rem;
-  padding: 1.5rem 1rem 1.5rem 0;
-  text-align: center;
-}
-  .nav__room {
-    padding-top: 6rem;
-  }
-  .breakpoint-phone .nav--header {
-    display: none;
-  }
-
-  .nav--header {
-    position: fixed;
-    background-color: white;
-    width: 100%;
-    top: 0;
-    z-index: 5;
-  }
-
-  .nav__content {
-    max-width: var(--max-width);
-    margin: 0 auto;
-    text-align: center;
-    display: flex;
-    flex-wrap: wrap;
-    align-content: space-between;
-    justify-content: space-between;
-  }
-  .nav__item {
-    display: inline;
-    font-size: 1.6rem;
-    padding-left: 1.5rem;
-    margin-left: 1rem;
-    text-decoration: none;
-  }
-  .nav__item--highlighted {
-    font-weight: bold;
-  }
-
-  .nav__item a:hover {
-    color: var(--primary-color-darker);
-  }
-
-  .nav--mobile {
-    transform-origin: 0 0;
-    transform: scale(0);
-    transition: transform .2s;
-    z-index: 1;
-  }
-  .nav--mobile.active {
-    transform: scale(1);
-  }
-
-  .breakpoint-tablet .nav--mobile,
-  .breakpoint-tablet .nav--mobile__show,
-  .breakpoint-desktop-up .nav--mobile,
-  .breakpoint-desktop-up .nav--mobile__show {
-    display: none;
-  }
-
-  .breakpoint-phone .nav__room {
-    padding-top: 4em;
-  }
-
-  .nav--mobile__show {
-    position: fixed;
-    background-color: #FFFFFF;
-    width: 100%;
-    top: 0;
-    z-index: 6;
-    padding: 2rem;
-    font-size: 2rem;
-    border-bottom: 1px solid #EEE;
-    color: var(--text-color);
-  }
-  .nav--mobile__show:visited {
-    color: var(--text-color);
-  }
-  .nav--mobile__show::before {
-    content: '';
-    background: url("/assets/public/images/bg_menu.svg") 50% 0 no-repeat;
-    display: inline-block;
-    width: 2rem;
-    height: 2rem;
-    vertical-align: middle;
-    margin-right: 1rem;
-  }
-
-  .breakpoint-phone .nav--mobile .nav__content {
-    background: var(--primary-contrast);
-    width: 100%;
-    padding-top: 6rem;
-    padding-bottom: 3rem;
-    z-index: 5;
-    text-align: left;
-  }
-
-  .breakpoint-phone .nav.nav--mobile {
-    position: fixed;
-    padding: 0;
-    margin: 0;
-    top: 0;
-    width: 100%;
-  }
-
-  .nav--mobile .nav__item {
-    font-size: 2rem;
-    padding: 1rem 0rem;
-    display: block;
-    margin-left: 4rem;
-    margin-right: 2rem;  }
-
-  .nav--mobile .nav__item a {
-    padding: 0.5rem;
-    padding-left: 0;
-    color: #FFF;
-  }
-
-  a.nav-offset__anchor {
-    position: absolute;
-    top: -12rem;
-  }
-  .nav-offset__container {
-    position: relative;
-  }
 /*header/nav*/
 .header {
   width: 100%;

--- a/source/assets/public/index.js
+++ b/source/assets/public/index.js
@@ -1,10 +1,10 @@
 /**
  * JavaScript goes here
  */
-
 function mobileMenu() {
+  var NAV_ACTIVE_CLASS = 'js-active';
   var body = document.body;
-  var mobileNavContainer = document.querySelector('.nav--mobile');
+  var mobileNavContainer = document.querySelector('nav');
   var mobileNavTrigger = document.querySelector('.nav--mobile__show');
 
   function bodyClickHandler(event) {
@@ -13,17 +13,17 @@ function mobileMenu() {
     closeMenu();
   }
   function openMenu () {
-    mobileNavContainer.classList.add('active');
+    mobileNavContainer.classList.add(NAV_ACTIVE_CLASS);
     body.addEventListener('click', bodyClickHandler);
   }
   function closeMenu () {
-    mobileNavContainer.classList.remove('active');
+    mobileNavContainer.classList.remove(NAV_ACTIVE_CLASS);
     body.removeEventListener('click', bodyClickHandler);
   }
 
   mobileNavTrigger.addEventListener('click', function(e) {
     e.preventDefault();
-    mobileNavContainer.classList.contains('active') ? closeMenu() : openMenu();
+    mobileNavContainer.classList.contains(NAV_ACTIVE_CLASS) ? closeMenu() : openMenu();
   });
 }
 window.mobileMenu = mobileMenu;

--- a/source/assets/public/index.js
+++ b/source/assets/public/index.js
@@ -4,7 +4,7 @@
 function mobileMenu() {
   var NAV_ACTIVE_CLASS = 'js-active';
   var body = document.body;
-  var mobileNavContainer = document.querySelector('nav');
+  var mobileNavContainer = document.querySelector('#menu');
   var mobileNavTrigger = document.querySelector('.nav--mobile__show');
 
   function bodyClickHandler(event) {

--- a/source/layouts/base.slim
+++ b/source/layouts/base.slim
@@ -18,10 +18,9 @@ html lang="en-NZ"
     = partial "partials/head_pwa"
     script async=true src=asset_path(:js, "assets/public")
   body.nav__room
-    a.nav--mobile__show href="#menu_mobile"
+    a.nav--mobile__show href="#menu"
       | Menu
-    = partial "partials/nav", locals: { nav_type: "header" }
-    = partial "partials/nav", locals: { nav_type: "mobile" }
+    = partial "partials/nav"
     .mw-spacer
       .container
         = yield

--- a/source/partials/_nav.html.slim
+++ b/source/partials/_nav.html.slim
@@ -1,7 +1,7 @@
-.nav (class="nav--#{nav_type}" id="menu_#{nav_type}" data-turbolinks-permanent)
-  ul.nav__content
-    li.nav__item
+nav (id="menu" data-turbolinks-permanent)
+  ul
+    li
       a href="/" Kiwi&nbsp;Ruby
     - data.nav.nav_items.each do |item|
-      li.nav__item class=("nav__item--highlighted" if item.highlighted)
+      li class=("nav__item--highlighted" if item.highlighted)
         a href=item.link rel=("noopener" if item.external) = item.title


### PR DESCRIPTION
Instead of having duplicate HTML elements for the mobile and desktop navs, this PR:

- fixes #37 
- consolidates the HTML,
- cleans up the CSS,
- adds a semantic `<nav>` wrapper
- removes the dependency on metaquery for the nav
- updates the menu script to suit the changes

<details>
<summary>Mobile screenshots</summary>

Before:
![cropped_mobile_before](https://user-images.githubusercontent.com/107569/31007969-e2bf86c6-a55e-11e7-9e1c-264852173404.png)

After:
![cropped_mobile_after](https://user-images.githubusercontent.com/107569/31007971-e2bff250-a55e-11e7-8341-a09b578d9ef0.png)

</details>

<details>
<summary>Tablet screenshots</summary>

Before:
![cropped_tablet_before](https://user-images.githubusercontent.com/107569/31007972-e2c15b36-a55e-11e7-84bf-160e2f69c5c2.png)

After:
![cropped_tablet_after](https://user-images.githubusercontent.com/107569/31007970-e2bff3cc-a55e-11e7-9082-d34e4c3af61a.png)

</details>

<details>
<summary>Desktop screenshots</summary>

Before: 
![cropped_desktop_before](https://user-images.githubusercontent.com/107569/31007973-e2dcafd0-a55e-11e7-8f02-e52ee649df66.png)

After:
![cropped_desktop_after](https://user-images.githubusercontent.com/107569/31007968-e2be5bf2-a55e-11e7-8ea7-80d3e0cd600b.png)

</details>


This will cause some conflicts with the #72 PR, but the `nav.css` changes here supersede the split css nav changes