### PR TITLE
Improve PostCSS output

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,9 @@ module.exports = {
           cssimport({
             addDependencyTo: webpack
           }),
-          cssnext()
+          cssnext({
+            browsers: '> 5%, ie 11, last 2 versions'
+          })
         ]
       };
     },


### PR DESCRIPTION
By setting the `browsers` key in the `postcss-cssnext` options, we can cut down a fifth of the output CSS, because the browserList defaults provide fallbacks for IE8.

e.g. when in default mode:

```
padding-top: 80px;
padding-top: 8rem;
```
…after this change to: `>5%, ie 11, last 2 versions`, it becomes:

```
padding-top: 8rem;
```

[`rem`s have great support](http://caniuse.com/#search=rem), even down to IE 9.

PostCSS seems pretty cool! I should use it more often :)